### PR TITLE
Disable turbo on anchor scrolling links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,9 +78,9 @@ module ApplicationHelper
   def scrolling_mobile_navigation_link(name:, path:)
     content_tag(:li, class: "py-2") do
       span_1 = if request.path == '/'
-        raw("<span @click=\"triggerMobileNavItem('#{path}')\" class=\"font-header font-semibold text-white uppercase pt-0.5 cursor-pointer\">#{name}</span>")
+        raw("<a @click=\"triggerMobileNavItem('#{path}')\" class=\"font-header font-semibold text-white uppercase pt-0.5 cursor-pointer\">#{name}</a>")
       else
-        content_tag(:a, href: "#{root_path}#{path}", class: "font-header font-semibold text-white uppercase pt-0.5") do
+        content_tag(:a, href: "#{root_path}#{path}", "data-turbo": "false", class: "font-header font-semibold text-white uppercase pt-0.5") do
           raw(name)
         end
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,9 +46,9 @@ module ApplicationHelper
   def scrolling_desktop_navigation_link(name:, path:)
     content_tag(:li, class: "group pl-6") do
       span_1 = if request.path == '/'
-        raw("<span @click=\"triggerNavItem('#{path}')\" class=\"font-header font-semibold text-white uppercase pt-0.5 cursor-pointer\">#{name}</span>")
+        raw("<a @click=\"triggerNavItem('#{path}')\" class=\"font-header font-semibold text-white uppercase pt-0.5 cursor-pointer\">#{name}</a>")
       else
-        content_tag(:a, href: "#{root_path}#{path}", 'data-turbo-action': 'replace', class: "font-header font-semibold text-white uppercase pt-0.5 cursor-pointer") do
+        content_tag(:a, href: "#{root_path}#{path}", "data-turbo": "false", class: "font-header font-semibold text-white uppercase pt-0.5 cursor-pointer") do
           raw(name)
         end
       end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,7 +36,7 @@ html[lang="en"]
     link[href="https://unpkg.com/boxicons@2.1.1/css/boxicons.min.css" rel="stylesheet"]
     
     - # staging/production require this
-    = stylesheet_pack_tag 'application'
+    = stylesheet_pack_tag 'application', 'data-turbo-track': 'reload'
     
     - # this is the webpack insertion point, including ALL tailwind CSS imported by application.js...so confusing
     = javascript_pack_tag 'application', 'data-turbo-track': 'reload'

--- a/app/views/shared/_social_icons.html.slim
+++ b/app/views/shared/_social_icons.html.slim
@@ -2,7 +2,7 @@
 
 div[class=" flex items-center justify-center sm:justify-start pt-5 sm:pt-0 pl-2"]
   a href="https://www.linkedin.com/in/benradler/" title="LinkedIn" 
-    i[class="bx bxl-linkedin text-2xl #{icon_classes}"]
+    i[class="bx bxl-linkedin-square text-2xl #{icon_classes}"]
   a.pl-4 href="https://github.com/lordnibbler/" title="Github" 
     i[class="bx bxl-github text-2xl #{icon_classes}"]
   a.pl-4 href="https://stackoverflow.com/users/418864/professormeowingtons" title="StackOverflow" 


### PR DESCRIPTION
There are two issues at play here:

* we're using alpine.js to override the click behavior of the `<a>` tags in the navigation which link to page anchors on the homepage. so, instead of "jumping" immediately to the anchored section of the page, we disable the default browser behavior, and scroll the anchored section into view for a more seamless experience.
* doing this prevents `history.pushState` (or whatever the browser uses internally to set the URL when a user clicks a link) from happening. so as such, we dont end up with `/#about` or `/#work` appended to the URL. this breaks the browser's back button behavior.
* turbo (and the old turbolinks we replaced recently) will intercept any `<a>` click and attempt to replace ONLY the part of the page which changes. however, with anchor links this behavior is a little janky, and it appears to still make a request to the `HomeController#show` endpoint even though it is just an anchor link. they claim to have fixed this (https://github.com/turbolinks/turbolinks/issues/75) but i don't see this fix working, so we disable turbo for the anchor link `<a>` tags for now 

This PR disables turbo for the anchor links in the navigation, which fixes a lot of the buggy behavior from turbo. However, the alpine.js code still makes it such that the anchor isn't appended to the url. i tried doing this with native js instead of alpine (https://stackoverflow.com/questions/7717527/smooth-scrolling-when-clicking-an-anchor-link) and same issue occurs, no URL change when clicking anchors. also tried pure CSS `scroll-behavior: smooth` and this is just super inconsistent between browsers. firefox only works for anchors that are visible on the page, chrome works fine, and safari doesnt work at all (https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior)