### PR TITLE
JS + Styles cleanup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :set_meta_tags_title
-  before_action :set_navigation_class
 
   private
 
@@ -24,13 +23,5 @@ class ApplicationController < ActionController::Base
   #
   def body_class(name)
     @body_class = "#{name}-template"
-  end
-
-  #
-  # home page nav should be fully transparent until scrolling
-  # all other pages require opaque bg
-  #
-  def set_navigation_class
-    @navigation_class = request.path == '/' ? 'bg-primary/0 dark:bg-primary-50/0' : 'bg-primary dark:bg-primary-50'
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,14 +65,21 @@ module ApplicationHelper
   # @return [String] desktop navigation link for links that scroll the homepage when clicked,
   # or link visitor pre-scrolled to the section
   #
-  # rubocop:disable Layout/LineLength
   def scrolling_desktop_navigation_link(name:, path:)
     content_tag(:li, class: 'group pl-6') do
       span1 = if request.path == '/'
-                content_tag(:a, name, '@click': "triggerNavItem('#{path}')", class: 'font-header font-semibold text-white uppercase pt-0.5 cursor-pointer')
+                content_tag(
+                  :a,
+                  name,
+                  '@click': "triggerNavItem('#{path}')",
+                  class: 'font-header font-semibold text-white uppercase pt-0.5 cursor-pointer',
+                )
               else
-                content_tag(:a, href: "#{root_path}#{path}", 'data-turbo': 'false',
-                                class: 'font-header font-semibold text-white uppercase pt-0.5 cursor-pointer',) do
+                content_tag(
+                  :a,
+                  href: "#{root_path}#{path}", 'data-turbo': 'false',
+                  class: 'font-header font-semibold text-white uppercase pt-0.5 cursor-pointer',
+                ) do
                   name
                 end
               end
@@ -82,7 +89,6 @@ module ApplicationHelper
       span1 + span2
     end
   end
-  # rubocop:enable Layout/LineLength
 
   #
   # @return [String] mobile navigation link for links that dont scroll the homepage when clicked
@@ -99,14 +105,22 @@ module ApplicationHelper
   # @return [String] mobile navigation link for links that scroll the homepage when clicked,
   # or link visitor pre-scrolled to the section
   #
-  # rubocop:disable Layout/LineLength
   def scrolling_mobile_navigation_link(name:, path:)
     content_tag(:li, class: 'py-2') do
       span1 = if request.path == '/'
-                content_tag(:a, name, '@click': "triggerMobileNavItem('#{path}')", class: 'font-header font-semibold text-2xl text-white uppercase pt-1 cursor-pointer')
+                content_tag(
+                  :a,
+                  name,
+                  '@click': "triggerMobileNavItem('#{path}')",
+                  class: 'font-header font-semibold text-2xl text-white uppercase pt-1 cursor-pointer',
+                )
               else
-                content_tag(:a, href: "#{root_path}#{path}", 'data-turbo': 'false',
-                                class: 'font-header font-semibold text-2xl text-white uppercase pt-1',) do
+                content_tag(
+                  :a,
+                  href: "#{root_path}#{path}",
+                  'data-turbo': 'false',
+                  class: 'font-header font-semibold text-2xl text-white uppercase pt-1',
+                ) do
                   name
                 end
               end
@@ -116,5 +130,4 @@ module ApplicationHelper
       span1 + span2
     end
   end
-  # rubocop:enable Layout/LineLength
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
   # so dont use --app-height js on photography_path
   #
   def main_styles
-    current_page?(photography_path) ? "" : "height: 100vh; height: var(--app-height, 100vh);"
+    current_page?(photography_path) ? '' : 'height: 100vh; height: var(--app-height, 100vh);'
   end
 
   #

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,28 @@ module ApplicationHelper
   end
 
   #
+  # sets main_styles ivar such that footer is stuck to bottom of page,
+  # based on --app-height variable set on resize in custom.js
+  #
+  # this solves for iOS bug where navigation bar covers some of the page
+  # and creates unnecessary scrollable area when there is minimal content on page.
+  #
+  # photography page has dynamically determined height by infinite-scroll,
+  # so dont use --app-height js on photography_path
+  #
+  def main_styles
+    current_page?(photography_path) ? "" : "height: 100vh; height: var(--app-height, 100vh);"
+  end
+
+  #
+  # home page nav should be fully transparent until scrolling
+  # all other pages require opaque bg
+  #
+  def navigation_class
+    current_page?(root_path) ? 'bg-primary/0 dark:bg-primary-50/0' : 'bg-primary dark:bg-primary-50'
+  end
+
+  #
   # @return [String] desktop navigation link for links that dont scroll the homepage when clicked
   #
   def desktop_navigation_link(name:, path:)

--- a/app/javascript/packs/blog.js
+++ b/app/javascript/packs/blog.js
@@ -1,0 +1,6 @@
+import fitvids from 'fitvids';
+
+$(document).on('turbo:load', function() {
+  // ensure videos fit full width of page
+  fitvids('#main');
+});

--- a/app/javascript/packs/blog.js
+++ b/app/javascript/packs/blog.js
@@ -1,6 +1,6 @@
 import fitvids from 'fitvids';
 
-$(document).on('turbo:load', function() {
+$(document).on('turbo:load', () => {
   // ensure videos fit full width of page
   fitvids('#main');
 });

--- a/app/javascript/packs/custom.js
+++ b/app/javascript/packs/custom.js
@@ -1,5 +1,3 @@
-import fitvids from 'fitvids';
-
 const setupAppHeightHandler = () => {
   // webkit "bug" means 100vh includes hidden area below navigation bar on iOS/iPadOS
   // set a css variable `--appHeight` so we can use the window's innerHeight to set the page height
@@ -59,9 +57,6 @@ $(document).on('turbo:load', function() {
 
   // make navigation transparent when scrolling past 100px
   setupNavigationTransparencyHandler()
-
-  // ensure videos fit width of page
-  fitvids('#main');
 
   // flash auto-hiding
   $('.flash').on('click', function(event) {

--- a/app/javascript/packs/custom.js
+++ b/app/javascript/packs/custom.js
@@ -1,6 +1,6 @@
 import fitvids from 'fitvids';
 
-$(document).on('turbo:load', function() {
+const setupAppHeightHandler = () => {
   // webkit "bug" means 100vh includes hidden area below navigation bar on iOS/iPadOS
   // set a css variable `--appHeight` so we can use the window's innerHeight to set the page height
   // link: https://bugs.webkit.org/show_bug.cgi?id=141832
@@ -15,15 +15,9 @@ $(document).on('turbo:load', function() {
     resizeComplete = this.setTimeout(appHeight, 100);
   });
   appHeight();
+}
 
-  // ensure videos fit width of page
-  fitvids('#main');
-
-  // flash auto-hiding
-  $('.flash').on('click', function(event) {
-    $(this).slideUp();
-  });
-
+const setupNavigationTransparencyHandler = () => {
   function navTransparencyHandler() {
     //
     // when page is scrolled down >=100px, make the navigation 95% transparent
@@ -38,7 +32,7 @@ $(document).on('turbo:load', function() {
     }
 
     // event listener logic, when page scrolls past 100px y-axis, switch CSS background
-    let navElement = document.querySelector(".desktop-nav");
+    const navElement = document.querySelector(".desktop-nav");
     if (this.scrollY > 100 || this.scrollY === undefined) {
       navElement.classList.add(...scrolledClasses)
       navElement.classList.remove(...notScrolledClasses)
@@ -51,9 +45,26 @@ $(document).on('turbo:load', function() {
   // run once on homepage load to ensure classes are set appropriately,
   // in case of linking straight to homepage on an anchor (hash)
   if (window.location.pathname === "/" && window.location.hash) {
-    navTransparencyHandler.bind(this)()
+    navTransparencyHandler()
   }
 
   // when page scrolls, update nav transparency as needed
   window.addEventListener("scroll", navTransparencyHandler, false)
+}
+
+$(document).on('turbo:load', function() {
+  // resize page height according to window.innerHeight to avoid navigation bar
+  // on iOS causing extra scrollable area when page has very little content
+  setupAppHeightHandler()
+
+  // make navigation transparent when scrolling past 100px
+  setupNavigationTransparencyHandler()
+
+  // ensure videos fit width of page
+  fitvids('#main');
+
+  // flash auto-hiding
+  $('.flash').on('click', function(event) {
+    $(this).slideUp();
+  });
 });

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -12,3 +12,8 @@ html {
 }
 
 @tailwind utilities;
+
+#main {
+    height: 100vh;
+    height: var(--app-height, 100vh);
+}

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -12,8 +12,3 @@ html {
 }
 
 @tailwind utilities;
-
-#main {
-    height: 100vh;
-    height: var(--app-height, 100vh);
-}

--- a/app/views/blog/posts/index.html.erb
+++ b/app/views/blog/posts/index.html.erb
@@ -3,6 +3,10 @@
   description: 'Ben Radler is an Engineer in San Francisco. He uses technology like Ruby, Rails, Javascript, Node.js',
 ) %>
 
+<% content_for :head do %>
+  <%= javascript_pack_tag 'blog', 'data-turbo-track': 'reload' %>
+<% end %>
+
 <div class="dark:bg-primary-20">
     <div class="container py-6 md:py-10 mt-12 sm:mt-16 lg:mt-18 xl:mt-16">
       <% @posts.each do |post| %>

--- a/app/views/blog/posts/show.html.erb
+++ b/app/views/blog/posts/show.html.erb
@@ -3,6 +3,10 @@
     description: meta_description_markdown(@post.body)
 ) %>
 
+<% content_for :head do %>
+  <%= javascript_pack_tag 'blog', 'data-turbo-track': 'reload' %>
+<% end %>
+
 <div class="dark:bg-primary-20">
     <div class="container py-6 md:py-10 mt-12 sm:mt-16 lg:mt-18 xl:mt-16">
         <div class="max-w-4xl mx-auto">

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -61,9 +61,7 @@ html[lang="en"]
     = yield :head
     = csrf_meta_tags
   body[class="#{@body_class}" :class="{ 'overflow-hidden max-h-screen': mobileMenu }" x-data="{ mobileMenu: false }"]
-    - # photography page has dynamically determined height by infinite-scroll, dont use --app-height js
-    - main_styles = current_page?(photography_path) ? "" : "height: 100vh; height: var(--app-height, 100vh);"
-    div[id="main" class="flex flex-col" style=main_styles]
+    div[id="main" class="flex flex-col" style="#{main_styles}"]
       = render 'shared/header'
       = render 'shared/flash'
       - if controller_name =~ /pages|errors/

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
     }
 }">
     <% # desktop navigation %>
-    <div class="desktop-nav fixed transition ease-in-out duration-300 w-full z-50 top-0 py-3 sm:py-5 <%= @navigation_class %>">
+    <div class="desktop-nav fixed transition ease-in-out duration-300 w-full z-50 top-0 py-3 sm:py-5 <%= navigation_class %>">
         <div class="container flex justify-between items-center">
             <div>
                 <a href="/" class="uppercase text-white text-2xl sm:text-4xl lg:text-2xl xl:text-4xl">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -48,6 +48,34 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'main_styles' do
+    it 'returns empty string for photography_path' do
+      allow(helper).to receive(:current_page?).and_return(true)
+
+      expect(helper.main_styles).to eql('')
+    end
+
+    it 'returns appropriate styles for non-photography_path' do
+      allow(helper).to receive(:current_page?).and_return(false)
+
+      expect(helper.main_styles).to eql('height: 100vh; height: var(--app-height, 100vh);')
+    end
+  end
+
+  describe 'navigation_class' do
+    it 'returns appropriate styles for root_path' do
+      allow(helper).to receive(:current_page?).and_return(true)
+
+      expect(helper.navigation_class).to eql('bg-primary/0 dark:bg-primary-50/0')
+    end
+
+    it 'returns appropriate styles for non-root_path' do
+      allow(helper).to receive(:current_page?).and_return(false)
+
+      expect(helper.navigation_class).to eql('bg-primary dark:bg-primary-50')
+    end
+  end
+
   describe 'desktop_navigation_link' do
     it 'returns a desktop navigation link HTML' do
       link = helper.desktop_navigation_link(name: 'Home', path: root_path)


### PR DESCRIPTION
## Description
- moves `set_navigation_class` from `ApplicationController` to `ApplicationHelper`, as it makes more sense to live there (using route helpers, and is not controller-specific)
- creates a `main_styles` function in `ApplicationController` which helps us apply the proper `100vh` styles to the `#main` container div on all pages except `photography_path`
- creates a new webpack pack `blog.js`, migrating the `fitvids` js there as we no longer need it on the homepage (and in fact it was causing a weird 1px white line at the bottom of the homepage, so we solve the resize with pure CSS in a [previous PR](https://github.com/Lordnibbler/railsblog/commit/5b12c8abcc46d7c447abe750270a332001c587a3)
- cleanup `custom.js` to have two reusable functions instead of large walls of code

## Todo
- [x] unit tests for `ApplicationHelper`
- [x] move any relevant `ApplicationController` unit tests