### PR TITLE
allow mobile nav to scroll

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -38,7 +38,7 @@
     </div>
 
     <% # mobile navigation %>
-    <div class="fixed inset-0 bg-black bg-opacity-70 z-50 min-h-full lg:hidden transition-opacity opacity-0 pointer-events-none"
+    <div class="fixed inset-0 bg-black bg-opacity-70 z-50 min-h-full lg:hidden transition-opacity opacity-0 pointer-events-none overflow-auto"
         :class="{ 'opacity-100 pointer-events-auto': $parent.mobileMenu }">
         <div class="w-2/3 md:w-1/3 bg-primary dark:bg-primary-50 min-h-full absolute right-0 shadow py-4 px-8">
 


### PR DESCRIPTION
iPhone 12 Pro in landscape cannot see all mobile nav links.