### PR TITLE
cache warmer fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ AllCops:
     - Gemfile
     - app/helpers/application_helper.rb
 
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rails
@@ -77,7 +77,7 @@ Style/Next:
 Style/DoubleNegation:
   Enabled: false
 
-HasAndBelongsToMany:
+Rails/HasAndBelongsToMany:
   Enabled: false
 
 Metrics/AbcSize:

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN if [ "$RAILS_ENV" = "production" ]; then \
       # now that ENV is set, compile assets
       bundle exec rails assets:precompile; \
     fi
-# 9) Copy in the entrypoint and release scripts (to migrate db, warm cache, start puma server)
+# 9) Copy in the entrypoint and release scripts (to migrate db and start puma server)
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 COPY release-tasks.sh /usr/bin/release-tasks.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
     bigdecimal (4.1.2)
-    binding_of_caller (1.0.1)
+    binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
     brakeman (7.1.2)
       racc

--- a/README.md
+++ b/README.md
@@ -121,12 +121,13 @@ open "http://localhost:3000"
 
 This app is deployed to heroku via a docker container, using the `container` stack.
 
-No Procfile needed due to [`heroku.yml`](https://www.heroku.com/blog/build-docker-images-heroku-yml/). Heroku will honor this manifest instead. On each `container:release`, Heroku will run [`entrypoint.sh`](./entrypoint.sh):
+No Procfile needed due to [`heroku.yml`](https://www.heroku.com/blog/build-docker-images-heroku-yml/). Heroku will honor this manifest instead. On each `container:release`:
 
 1. Pull the web image you just pushed.
-2. Run bundle exec rails db:migrate.
-3. Start bundle exec rails cache_warmer:flickr in the background if the Flickr cache is cold.
-4. Start web dyno with bundle exec puma -C config/puma.rb.
+2. Run the release phase command, [`release-tasks.sh`](./release-tasks.sh), which runs `bundle exec rails db:migrate`.
+3. Start the web dyno with [`entrypoint.sh`](./entrypoint.sh), which runs [`release-tasks.sh`](./release-tasks.sh) in production and then starts `bundle exec puma -C config/puma.rb`.
+
+The Flickr cache warmer is intentionally not part of web dyno startup. It runs via Heroku Scheduler so a slow Flickr response cannot make a freshly deployed web dyno return errors while it is coming up.
 
 ### Automatic Deployments
 
@@ -200,8 +201,8 @@ It uses Heroku Scheduler add on to run two recurring jobs:
 * `rails sitemap:refresh`
   * runs daily to refresh the sitemap file for the site
 * `rails cache_warmer:flickr`
-  * runs daily to fetch all Flickr photos for the photography page and write their metadata to redit. this job also shuffles the images so their order changes daily to keep the page looking fresh.
-  * photo cache itself expires after 3 days, and a single warm cache key expires after 1 day. as a result, back to back deploys do not trigger a re-warm of the cache, and if a scheduler job fails to run we won't be likely to be left without a cache since there are 2 more attempts in the next 48h.
+  * runs daily to fetch all Flickr photos for the photography page and write their metadata to redis. this job also shuffles the images so their order changes daily to keep the page looking fresh.
+  * photo cache itself expires after 3 days, and a single warm cache key expires after 25 hours. the scheduler job always refreshes the cache instead of skipping when the warm key is present, so the daily run keeps extending both the photo cache and the warm marker.
 
 
 ### CDN

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ No Procfile needed due to [`heroku.yml`](https://www.heroku.com/blog/build-docke
 
 1. Pull the web image you just pushed.
 2. Run bundle exec rails db:migrate.
-3. Run bundle exec rails cache_warmer:flickr.
+3. Start bundle exec rails cache_warmer:flickr in the background if the Flickr cache is cold.
 4. Start web dyno with bundle exec puma -C config/puma.rb.
 
 ### Automatic Deployments

--- a/app/services/flickr_service.rb
+++ b/app/services/flickr_service.rb
@@ -1,6 +1,7 @@
 require 'flickr'
 
 # interface for fetching and caching photos from flickr API
+# rubocop:disable Metrics/ClassLength
 class FlickrService
   # This class is responsible for fetching and caching photos from Flickr API
   # It provides methods to warm up the cache, fetch photos from cache or directly from Flickr
@@ -277,3 +278,4 @@ class FlickrService
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/flickr_service.rb
+++ b/app/services/flickr_service.rb
@@ -38,25 +38,26 @@ class FlickrService
     # @param pages [Integer] number of pages to fetch from Flickr
     # @return [void]
     def warm_cache_shuffled(pages: nil)
-      pages ||= total_pages
+      started_at = monotonic_time
+      pages ||= timed('fetching total Flickr pages') { total_pages }
       logger.info("Concurrently fetching #{pages} total pages of photos from Flickr")
 
-      photos = fetch_and_randomize_photos(pages)
+      photos = timed("fetching and randomizing #{pages} pages") { fetch_and_randomize_photos(pages) }
 
       # 3. Cache the individual photos
       # example cache key: flickr_photo/49822914933
-      cache_photos(photos)
+      timed("writing #{photos.count} individual photos to cache") { cache_photos(photos) }
 
       # 4. Cache photos in batches of `per_page` size
       # example cache key: flickr_photos/33668819@N03_20_1
       logger.info("Writing #{pages} pages of photos to cache")
-      cache_photos_in_batches(photos, pages)
+      timed("writing #{pages} page batches to cache") { cache_photos_in_batches(photos, pages) }
 
       logger.info("Wrote #{photos.count} photos to cache")
       logger.info("Example photo cache key: #{self.generate_photo_cache_key(photo_id: photos[0][:key])}")
       logger.info("Example batch cache key: #{self.generate_page_cache_key(user_id: FLICKR_USER_ID, page: 1,
                                                                            per_page: 20,)}")
-      logger.info('Done')
+      logger.info("Done in #{elapsed_since(started_at)}s")
     end
 
     # Fetches photos from Flickr
@@ -114,8 +115,18 @@ class FlickrService
     # @param pages [Integer] number of pages to fetch from Flickr
     # @return [Array<Hash>] array of randomized photo data
     def fetch_and_randomize_photos(pages)
-      futures = (1..pages).map { |page| fetch_photos_future(page) }
-      futures.map(&:value).flatten.compact.shuffle
+      concurrency = Integer(ENV.fetch('FLICKR_CACHE_WARMER_CONCURRENCY', 2))
+      logger.info("fetching Flickr pages with concurrency #{concurrency}")
+
+      (1..pages).each_slice(concurrency).flat_map do |page_batch|
+        futures = page_batch.map { |page| [page, fetch_photos_future(page)] }
+        futures.flat_map do |page, future|
+          future.value!
+        rescue StandardError => e
+          logger.error("failed to fetch page #{page}: #{e.class}: #{e.message}")
+          raise
+        end
+      end.shuffle
     end
 
     def fetch_photos_future(page)
@@ -127,20 +138,43 @@ class FlickrService
     # @param attempts [Integer] number of attempts made to fetch photos
     # @return [Array<Hash>, nil] array of photo data or nil if an error occurs
     def fetch_photos_with_retry(page, attempts = 0)
+      started_at = monotonic_time
       logger.info("fetching page #{page} from flickr on attempt #{attempts}")
-      get_photos_from_flickr(page:)
-    rescue Errno::ECONNRESET => e
+      get_photos_from_flickr(page:).tap do |photos|
+        logger.info("fetched page #{page} with #{photos&.count || 0} photos in #{elapsed_since(started_at)}s")
+      end
+    rescue StandardError => e
+      raise unless retryable_flickr_error?(e)
+
       retry_or_raise_error(page, attempts, e)
     end
 
     def retry_or_raise_error(page, attempts, error)
-      if attempts >= 5
-        logger.error("exhausted retries for page #{page}")
+      max_attempts = Integer(ENV.fetch('FLICKR_CACHE_WARMER_RETRIES', 5))
+      if attempts >= max_attempts
+        logger.error("exhausted retries for page #{page}: #{error.class}: #{error.message}")
         raise error
       end
 
-      logger.info("future for page #{page} retrying")
+      logger.info("future for page #{page} retrying after #{error.class}: #{error.message}")
       fetch_photos_with_retry(page, attempts + 1)
+    end
+
+    def retryable_flickr_error?(error)
+      retryable_errors = [
+        Errno::ECONNRESET,
+        EOFError,
+        JSON::ParserError,
+        Net::OpenTimeout,
+        Net::ReadTimeout,
+        Timeout::Error,
+      ]
+
+      retryable_errors.any? { |error_class| error.is_a?(error_class) } || flickr_service_unavailable?(error)
+    end
+
+    def flickr_service_unavailable?(error)
+      error.is_a?(Flickr::FailedResponse) && error.message.match?(/not currently available|unavailable|temporarily/i)
     end
 
     # Caches photos in rails cache
@@ -170,15 +204,18 @@ class FlickrService
     # @param response [Array<Hash>] response from Flickr API
     # @return [Array<Hash>] array of normalized photo data
     def normalize(response:)
-      response.map { |photo| normalize_photo(photo) }
+      logger.info("normalizing #{response.count} photos")
+      response.map.with_index(1) do |photo, index|
+        timed("normalizing photo #{index}/#{response.count} id=#{photo.id}") { normalize_photo(photo) }
+      end
     end
 
     # Normalizes a single photo response from Flickr
     # @param photo [Hash] photo data to normalize
     # @return [Hash] normalized photo data
     def normalize_photo(photo)
-      get_photo_response = get_photo(photo.id)
-      sizes = client.photos.getSizes(photo_id: photo.id)
+      get_photo_response = timed("fetching info for photo #{photo.id}") { get_photo(photo.id) }
+      sizes = timed("fetching sizes for photo #{photo.id}") { client.photos.getSizes(photo_id: photo.id) }
       {
         source: 'flickr',
         key: photo.id,
@@ -223,6 +260,20 @@ class FlickrService
     # @return [String] cache key
     def generate_photo_cache_key(photo_id:)
       "flickr_photo/#{photo_id}"
+    end
+
+    def timed(label)
+      started_at = monotonic_time
+      logger.info("#{label} started")
+      yield.tap { logger.info("#{label} finished in #{elapsed_since(started_at)}s") }
+    end
+
+    def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def elapsed_since(started_at)
+      (monotonic_time - started_at).round(2)
     end
   end
 end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ $# -gt 0 ]; then
   exec "$@"
 fi
 
-# in production env, migrate the db and warm the flickr redis cache
+# in production env, run release tasks before starting the web server
 if [ "$RAILS_ENV" = "production" ]; then
   ./release-tasks.sh
 fi

--- a/heroku.yml
+++ b/heroku.yml
@@ -3,13 +3,8 @@ build:
     web: Dockerfile
 
 release:
-  # this is SUPPOSED be run after the web image is released, but it never gets triggered
-  # the release phase starts the web image, which starts puma instead of running the
-  # command below.
-  # To work around it, I moved the same release steps into entrypoint.sh
-  # This `command` stanza is here for posterity but is UNUSED.
   # Docs: https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#release-configure-release-phase
-  command: ./deployment-tasks.sh
+  command: ./release-tasks.sh
 
 run:
   web:

--- a/lib/tasks/cache_warmer.rake
+++ b/lib/tasks/cache_warmer.rake
@@ -8,10 +8,6 @@ namespace :cache_warmer do
     if Rails.cache.fetch(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY) == true
       Rails.logger.info('--->  Cache Warmer: Cache already warm, exiting')
     else
-      # clear out the existing Rails.cache
-      Rails.logger.info('--->  Cache Warmer: Clearing existing cache')
-      Rails.cache.clear
-
       # warm the cache for num_pages worth of Flickr photos, saving
       # each page to a random index between 1..num_pages
       Rails.logger.info('--->  Cache Warmer: Warming Flickr cache')
@@ -24,5 +20,4 @@ namespace :cache_warmer do
     end
   end
 end
-
 

--- a/lib/tasks/cache_warmer.rake
+++ b/lib/tasks/cache_warmer.rake
@@ -2,6 +2,7 @@ namespace :cache_warmer do
   # usage: bx rails 'cache_warmer:flickr'
   desc 'Warms cache for flickr API'
   task flickr: :environment do |_task, _args|
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     Rails.logger.info('--->  Cache Warmer: starting...')
 
     # return if cache is warm already when deploying, avoiding unnecessary calls to flickr
@@ -18,6 +19,8 @@ namespace :cache_warmer do
 
       Rails.logger.info('--->  Cache Warmer: completed warming cache')
     end
+  ensure
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    Rails.logger.info("--->  Cache Warmer: finished in #{elapsed.round(2)}s")
   end
 end
-

--- a/lib/tasks/cache_warmer.rake
+++ b/lib/tasks/cache_warmer.rake
@@ -5,20 +5,13 @@ namespace :cache_warmer do
     started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     Rails.logger.info('--->  Cache Warmer: starting...')
 
-    # return if cache is warm already when deploying, avoiding unnecessary calls to flickr
-    if Rails.cache.fetch(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY) == true
-      Rails.logger.info('--->  Cache Warmer: Cache already warm, exiting')
-    else
-      # warm the cache for num_pages worth of Flickr photos, saving
-      # each page to a random index between 1..num_pages
-      Rails.logger.info('--->  Cache Warmer: Warming Flickr cache')
-      FlickrService.warm_cache_shuffled
+    Rails.logger.info('--->  Cache Warmer: Warming Flickr cache')
+    FlickrService.warm_cache_shuffled
 
-      Rails.logger.info('--->  Cache Warmer: Marking cache as warmed')
-      Rails.cache.write(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY, true, expires_in: 1.day)
+    Rails.logger.info('--->  Cache Warmer: Marking cache as warmed')
+    Rails.cache.write(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY, true, expires_in: 25.hours)
 
-      Rails.logger.info('--->  Cache Warmer: completed warming cache')
-    end
+    Rails.logger.info('--->  Cache Warmer: completed warming cache')
   ensure
     elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
     Rails.logger.info("--->  Cache Warmer: finished in #{elapsed.round(2)}s")

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -3,5 +3,16 @@ set -e
 
 echo "---- Release phase starting via release_tasks.sh ----"
 bundle exec rails db:migrate && echo "db:migrate finished"
-bundle exec rails cache_warmer:flickr && echo "cache_warmer done"
+
+if bundle exec rails runner 'exit(FlickrService.cache_warmed? ? 0 : 1)'; then
+  echo "flickr cache already warm"
+else
+  # Warm opportunistically so slow Flickr responses cannot block Puma startup.
+  (
+    timeout "${CACHE_WARMER_BOOT_TIMEOUT:-45s}" bundle exec rails cache_warmer:flickr \
+      && echo "cache_warmer done" \
+      || echo "cache_warmer skipped or timed out"
+  ) &
+fi
+
 echo "---- Release phase complete ----"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -3,16 +3,4 @@ set -e
 
 echo "---- Release phase starting via release_tasks.sh ----"
 bundle exec rails db:migrate && echo "db:migrate finished"
-
-if bundle exec rails runner 'exit(FlickrService.cache_warmed? ? 0 : 1)'; then
-  echo "flickr cache already warm"
-else
-  # Warm opportunistically so slow Flickr responses cannot block Puma startup.
-  (
-    timeout "${CACHE_WARMER_TIMEOUT:-${CACHE_WARMER_BOOT_TIMEOUT:-10m}}" bundle exec rails cache_warmer:flickr \
-      && echo "cache_warmer done" \
-      || echo "cache_warmer skipped or timed out"
-  ) &
-fi
-
 echo "---- Release phase complete ----"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -9,7 +9,7 @@ if bundle exec rails runner 'exit(FlickrService.cache_warmed? ? 0 : 1)'; then
 else
   # Warm opportunistically so slow Flickr responses cannot block Puma startup.
   (
-    timeout "${CACHE_WARMER_BOOT_TIMEOUT:-45s}" bundle exec rails cache_warmer:flickr \
+    timeout "${CACHE_WARMER_TIMEOUT:-${CACHE_WARMER_BOOT_TIMEOUT:-10m}}" bundle exec rails cache_warmer:flickr \
       && echo "cache_warmer done" \
       || echo "cache_warmer skipped or timed out"
   ) &

--- a/spec/services/flickr_service_spec.rb
+++ b/spec/services/flickr_service_spec.rb
@@ -164,4 +164,66 @@ describe FlickrService do
       expect(total_pages).to eq(8)
     end
   end
+
+  describe 'fetch_photos_with_retry' do
+    let(:logger) { instance_double(Logger, info: nil, error: nil) }
+
+    before do
+      allow(described_class).to receive(:logger).and_return(logger)
+    end
+
+    it 'retries retryable Flickr fetch failures' do
+      attempts = 0
+      photos = [{ key: '49822917268' }]
+
+      allow(described_class).to receive(:get_photos_from_flickr) do
+        attempts += 1
+        raise Net::ReadTimeout if attempts == 1
+
+        photos
+      end
+
+      expect(described_class.send(:fetch_photos_with_retry, 1)).to eq(photos)
+      expect(described_class).to have_received(:get_photos_from_flickr).with(page: 1).twice
+    end
+
+    it 'raises retryable failures after configured retries are exhausted' do
+      original_retries = ENV.fetch('FLICKR_CACHE_WARMER_RETRIES', nil)
+      ENV['FLICKR_CACHE_WARMER_RETRIES'] = '1'
+      error = EOFError.new('connection closed')
+
+      allow(described_class).to receive(:get_photos_from_flickr).and_raise(error)
+
+      expect { described_class.send(:fetch_photos_with_retry, 1) }.to raise_error(error)
+      expect(described_class).to have_received(:get_photos_from_flickr).with(page: 1).twice
+    ensure
+      ENV['FLICKR_CACHE_WARMER_RETRIES'] = original_retries
+    end
+
+    it 'does not retry non-retryable failures' do
+      error = ArgumentError.new('bad page')
+      allow(described_class).to receive(:get_photos_from_flickr).and_raise(error)
+
+      expect { described_class.send(:fetch_photos_with_retry, 1) }.to raise_error(error)
+      expect(described_class).to have_received(:get_photos_from_flickr).with(page: 1).once
+    end
+  end
+
+  describe 'fetch_and_randomize_photos' do
+    let(:logger) { instance_double(Logger, info: nil, error: nil) }
+
+    before do
+      allow(described_class).to receive(:logger).and_return(logger)
+    end
+
+    it 'uses future value bang so async failures are raised' do
+      future = instance_double(Concurrent::Future)
+      error = Net::ReadTimeout.new('timed out')
+
+      allow(future).to receive(:value!).and_raise(error)
+      allow(described_class).to receive(:fetch_photos_future).with(1).and_return(future)
+
+      expect { described_class.send(:fetch_and_randomize_photos, 1) }.to raise_error(error)
+    end
+  end
 end

--- a/spec/tasks/cache_warmer_spec.rb
+++ b/spec/tasks/cache_warmer_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 require 'rake'
 
+Rails.application.load_tasks
+
+# rubocop:disable RSpec/DescribeClass
 describe 'cache_warmer:flickr' do
   let(:task) { Rake::Task['cache_warmer:flickr'] }
   let(:logger) { instance_double(Logger, info: nil) }
-
-  before(:all) do
-    Rails.application.load_tasks
-  end
 
   before do
     task.reenable
@@ -57,3 +56,4 @@ describe 'cache_warmer:flickr' do
     expect(logger).to have_received(:info).with('--->  Cache Warmer: finished in 2.34s')
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/tasks/cache_warmer_spec.rb
+++ b/spec/tasks/cache_warmer_spec.rb
@@ -14,23 +14,7 @@ describe 'cache_warmer:flickr' do
     allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 12.34)
   end
 
-  it 'exits without warming when the cache is already warm' do
-    allow(Rails.cache).to receive(:fetch).with(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY).and_return(true)
-    allow(Rails.cache).to receive(:clear)
-    allow(Rails.cache).to receive(:write)
-    allow(FlickrService).to receive(:warm_cache_shuffled)
-
-    task.invoke
-
-    expect(FlickrService).not_to have_received(:warm_cache_shuffled)
-    expect(Rails.cache).not_to have_received(:clear)
-    expect(Rails.cache).not_to have_received(:write)
-    expect(logger).to have_received(:info).with('--->  Cache Warmer: Cache already warm, exiting')
-    expect(logger).to have_received(:info).with('--->  Cache Warmer: finished in 2.34s')
-  end
-
   it 'warms and marks the cache without clearing existing entries' do
-    allow(Rails.cache).to receive(:fetch).with(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY).and_return(false)
     allow(Rails.cache).to receive(:clear)
     allow(Rails.cache).to receive(:write)
     allow(FlickrService).to receive(:warm_cache_shuffled)
@@ -42,13 +26,14 @@ describe 'cache_warmer:flickr' do
     expect(Rails.cache).to have_received(:write).with(
       FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY,
       true,
-      expires_in: 1.day,
+      expires_in: 25.hours,
     )
+    expect(logger).to have_received(:info).with('--->  Cache Warmer: Warming Flickr cache')
+    expect(logger).to have_received(:info).with('--->  Cache Warmer: completed warming cache')
     expect(logger).to have_received(:info).with('--->  Cache Warmer: finished in 2.34s')
   end
 
   it 'logs elapsed time when warming fails' do
-    allow(Rails.cache).to receive(:fetch).with(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY).and_return(false)
     allow(FlickrService).to receive(:warm_cache_shuffled).and_raise(Net::ReadTimeout)
 
     expect { task.invoke }.to raise_error(Net::ReadTimeout)

--- a/spec/tasks/cache_warmer_spec.rb
+++ b/spec/tasks/cache_warmer_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'cache_warmer:flickr' do
+  let(:task) { Rake::Task['cache_warmer:flickr'] }
+  let(:logger) { instance_double(Logger, info: nil) }
+
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  before do
+    task.reenable
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(10.0, 12.34)
+  end
+
+  it 'exits without warming when the cache is already warm' do
+    allow(Rails.cache).to receive(:fetch).with(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY).and_return(true)
+    allow(Rails.cache).to receive(:clear)
+    allow(Rails.cache).to receive(:write)
+    allow(FlickrService).to receive(:warm_cache_shuffled)
+
+    task.invoke
+
+    expect(FlickrService).not_to have_received(:warm_cache_shuffled)
+    expect(Rails.cache).not_to have_received(:clear)
+    expect(Rails.cache).not_to have_received(:write)
+    expect(logger).to have_received(:info).with('--->  Cache Warmer: Cache already warm, exiting')
+    expect(logger).to have_received(:info).with('--->  Cache Warmer: finished in 2.34s')
+  end
+
+  it 'warms and marks the cache without clearing existing entries' do
+    allow(Rails.cache).to receive(:fetch).with(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY).and_return(false)
+    allow(Rails.cache).to receive(:clear)
+    allow(Rails.cache).to receive(:write)
+    allow(FlickrService).to receive(:warm_cache_shuffled)
+
+    task.invoke
+
+    expect(FlickrService).to have_received(:warm_cache_shuffled)
+    expect(Rails.cache).not_to have_received(:clear)
+    expect(Rails.cache).to have_received(:write).with(
+      FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY,
+      true,
+      expires_in: 1.day,
+    )
+    expect(logger).to have_received(:info).with('--->  Cache Warmer: finished in 2.34s')
+  end
+
+  it 'logs elapsed time when warming fails' do
+    allow(Rails.cache).to receive(:fetch).with(FlickrService::PHOTOGRAPHY_CACHE_WARMED_KEY).and_return(false)
+    allow(FlickrService).to receive(:warm_cache_shuffled).and_raise(Net::ReadTimeout)
+
+    expect { task.invoke }.to raise_error(Net::ReadTimeout)
+
+    expect(logger).to have_received(:info).with('--->  Cache Warmer: finished in 2.34s')
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the deploy-time Flickr cache warmer behavior that could make a freshly deployed Heroku web dyno return browser errors while cache warming was still running. Cache warming is now scheduler-owned, and the scheduled warmer always refreshes the cache so the warm marker does not expire between daily runs.

## Changes

- Removes Flickr cache warming from release/web startup; release tasks now only run `bundle exec rails db:migrate`.
- Points `heroku.yml` release phase at `./release-tasks.sh` and keeps web startup in `entrypoint.sh`.
- Makes `cache_warmer:flickr` always refresh Flickr data instead of exiting when the warm marker exists.
- Keeps existing cache entries during warming instead of clearing the entire Rails cache.
- Marks the Flickr cache warm for `25.hours` after a successful scheduler run.
- Improves Flickr warmer reliability with bounded page-fetch concurrency, retry handling for transient Flickr/network failures, async failure propagation via `value!`, and more detailed elapsed-time logging.
- Updates README deployment/scheduler docs to match the new startup and scheduler behavior.
- Adds focused specs for the cache warmer and Flickr retry/async failure handling.

## Verification

```sh
bash -n entrypoint.sh
bash -n release-tasks.sh
ruby -c lib/tasks/cache_warmer.rake
ruby -c spec/tasks/cache_warmer_spec.rb
```

Focused RSpec was not run locally because this machine is using system Ruby 2.6 and is missing Bundler `4.0.8`, which is required by `Gemfile.lock`.
